### PR TITLE
Support remote execution

### DIFF
--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -59,6 +59,8 @@ export interface IDatabaseRepository {
    * of Git and GitHub.
    */
   readonly isTutorialRepository?: boolean
+
+  readonly codespace?: boolean
 }
 
 /**

--- a/app/src/lib/git/add.ts
+++ b/app/src/lib/git/add.ts
@@ -12,5 +12,5 @@ export async function addConflictedFile(
   repository: Repository,
   file: WorkingDirectoryFileChange
 ) {
-  await git(['add', '--', file.path], repository.path, 'addConflictedFile')
+  await git(['add', '--', file.path], repository.path, 'addConflictedFile', {}, repository.codespace)
 }

--- a/app/src/lib/git/apply.ts
+++ b/app/src/lib/git/apply.ts
@@ -28,7 +28,9 @@ export async function applyPatchToIndex(
     await git(
       ['add', '--u', '--', file.status.oldPath],
       repository.path,
-      'applyPatchToIndex'
+      'applyPatchToIndex',
+      {},
+      repository.codespace
     )
 
     // Figure out the blob oid of the removed file
@@ -36,7 +38,9 @@ export async function applyPatchToIndex(
     const oldFile = await git(
       ['ls-tree', 'HEAD', '--', file.status.oldPath],
       repository.path,
-      'applyPatchToIndex'
+      'applyPatchToIndex',
+      {},
+      repository.codespace
     )
 
     const [info] = oldFile.stdout.split('\t', 1)
@@ -46,7 +50,9 @@ export async function applyPatchToIndex(
     await git(
       ['update-index', '--add', '--cacheinfo', mode, oid, file.path],
       repository.path,
-      'applyPatchToIndex'
+      'applyPatchToIndex',
+      {},
+      repository.codespace
     )
   }
 
@@ -78,7 +84,7 @@ export async function applyPatchToIndex(
   }
 
   const patch = await formatPatch(file, diff)
-  await git(applyArgs, repository.path, 'applyPatchToIndex', { stdin: patch })
+  await git(applyArgs, repository.path, 'applyPatchToIndex', { stdin: patch }, repository.codespace)
 
   return Promise.resolve()
 }
@@ -146,7 +152,5 @@ export async function discardChangesFromSelection(
 
   const args = ['apply', '--unidiff-zero', '--whitespace=nowarn', '-']
 
-  await git(args, repository.path, 'discardChangesFromSelection', {
-    stdin: patch,
-  })
+  await git(args, repository.path, 'discardChangesFromSelection', { stdin: patch}, repository.codespace)
 }

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -35,7 +35,7 @@ export async function createBranch(
     args.push('--no-track')
   }
 
-  await git(args, repository.path, 'createBranch')
+  await git(args, repository.path, 'createBranch', {}, repository.codespace)
 }
 
 /** Rename the given branch to a new name. */
@@ -47,7 +47,9 @@ export async function renameBranch(
   await git(
     ['branch', '-m', branch.nameWithoutRemote, newName],
     repository.path,
-    'renameBranch'
+    'renameBranch',
+    {},
+    repository.codespace
   )
 }
 
@@ -58,7 +60,7 @@ export async function deleteLocalBranch(
   repository: Repository,
   branchName: string
 ): Promise<true> {
-  await git(['branch', '-D', branchName], repository.path, 'deleteLocalBranch')
+  await git(['branch', '-D', branchName], repository.path, 'deleteLocalBranch', {}, repository.codespace)
   return true
 }
 
@@ -97,7 +99,8 @@ export async function deleteRemoteBranch(
         expectedErrors: new Set<DugiteError>([
           DugiteError.BranchDeletionFailed,
         ]),
-      })
+      },
+      repository.codespace)
     }
   )
 
@@ -139,7 +142,8 @@ export async function getBranchesPointedAt(
       // - 129 is returned if ref is malformed
       //   "warning: ignoring broken ref refs/remotes/origin/main."
       successExitCodes: new Set([0, 1, 129]),
-    }
+    },
+    repository.codespace
   )
   if (exitCode === 1 || exitCode === 129) {
     return null
@@ -167,7 +171,7 @@ export async function getMergedBranches(
 
   const args = ['branch', ...formatArgs, '--merged', branchName]
   const mergedBranches = new Map<string, string>()
-  const { stdout } = await git(args, repository.path, 'mergedBranches')
+  const { stdout } = await git(args, repository.path, 'mergedBranches', {}, repository.codespace)
 
   for (const branch of parse(stdout)) {
     // Don't include the branch we're using to compare against

--- a/app/src/lib/git/checkout-index.ts
+++ b/app/src/lib/git/checkout-index.ts
@@ -32,6 +32,7 @@ export async function checkoutIndex(
     'checkoutIndex',
     {
       stdin: paths.join('\0'),
-    }
+    },
+    repository.codespace
   )
 }

--- a/app/src/lib/git/checkout.ts
+++ b/app/src/lib/git/checkout.ts
@@ -107,7 +107,8 @@ export async function checkoutBranch(
       return git(args, repository.path, 'checkoutBranch', {
         ...opts,
         env: merge(opts.env, env),
-      })
+      },
+      repository.codespace)
     }
   )
 
@@ -124,7 +125,9 @@ export async function checkoutPaths(
   await git(
     ['checkout', 'HEAD', '--', ...paths],
     repository.path,
-    'checkoutPaths'
+    'checkoutPaths',
+    {},
+    repository.codespace
   )
 }
 
@@ -140,6 +143,8 @@ export async function checkoutConflictedFile(
   await git(
     ['checkout', `--${resolution}`, '--', file.path],
     repository.path,
-    'checkoutConflictedFile'
+    'checkoutConflictedFile',
+    {},
+    repository.codespace
   )
 }

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -174,7 +174,8 @@ export async function cherryPick(
     ],
     repository.path,
     'cherry-pick',
-    baseOptions
+    baseOptions,
+    repository.codespace
   )
 
   return parseCherryPickResult(result)
@@ -458,7 +459,8 @@ export async function continueCherryPick(
       ['commit', '--allow-empty'],
       repository.path,
       'continueCherryPickSkipCurrentCommit',
-      options
+      options,
+      repository.codespace
     )
 
     return parseCherryPickResult(result)
@@ -472,7 +474,8 @@ export async function continueCherryPick(
     ['cherry-pick', '--continue', '--keep-redundant-commits'],
     repository.path,
     'continueCherryPick',
-    options
+    options,
+    repository.codespace
   )
 
   return parseCherryPickResult(result)
@@ -480,7 +483,7 @@ export async function continueCherryPick(
 
 /** Abandon the current cherry pick operation */
 export async function abortCherryPick(repository: Repository) {
-  await git(['cherry-pick', '--abort'], repository.path, 'abortCherryPick')
+  await git(['cherry-pick', '--abort'], repository.path, 'abortCherryPick', {}, repository.codespace)
 }
 
 /**

--- a/app/src/lib/git/commit.ts
+++ b/app/src/lib/git/commit.ts
@@ -29,7 +29,8 @@ export async function createCommit(
     'createCommit',
     {
       stdin: message,
-    }
+    },
+    repository.codespace
   )
   return parseCommitSHA(result)
 }
@@ -93,7 +94,9 @@ export async function createMergeCommit(
       '--cleanup=strip',
     ],
     repository.path,
-    'createMergeCommit'
+    'createMergeCommit',
+    {},
+    repository.codespace
   )
   return parseCommitSHA(result)
 }

--- a/app/src/lib/git/core.ts
+++ b/app/src/lib/git/core.ts
@@ -129,7 +129,8 @@ export async function git(
   args: string[],
   path: string,
   name: string,
-  options?: IGitExecutionOptions
+  options?: IGitExecutionOptions,
+  remote_exec = false
 ): Promise<IGitResult> {
   const defaultOptions: IGitExecutionOptions = {
     successExitCodes: new Set([0]),
@@ -163,7 +164,7 @@ export async function git(
   const commandName = `${name}: git ${args.join(' ')}`
 
   const result = await GitPerf.measure(commandName, () =>
-    GitProcess.exec(args, path, opts)
+    GitProcess.exec(args, path, opts, remote_exec)
   ).catch(err => {
     // If this is an exception thrown by Node.js (as opposed to
     // dugite) let's keep the salient details but include the name of

--- a/app/src/lib/git/diff-check.ts
+++ b/app/src/lib/git/diff-check.ts
@@ -8,7 +8,8 @@ import { getCaptures } from '../helpers/regex'
  * @returns filepaths with their number of conflicted markers
  */
 export async function getFilesWithConflictMarkers(
-  repositoryPath: string
+  repositoryPath: string,
+  remote = false
 ): Promise<Map<string, number>> {
   // git operation
   const args = ['diff', '--check']
@@ -16,7 +17,9 @@ export async function getFilesWithConflictMarkers(
     args,
     repositoryPath,
     'getFilesWithConflictMarkers',
-    new Set([0, 2])
+    new Set([0, 2]),
+    undefined,
+    remote
   )
 
   // result parsing

--- a/app/src/lib/git/diff-index.ts
+++ b/app/src/lib/git/diff-index.ts
@@ -87,7 +87,8 @@ export async function getIndexChanges(
     'getIndexChanges',
     {
       successExitCodes: new Set([0, 128]),
-    }
+    },
+    repository.codespace
   )
 
   // 128 from diff-index either means that the path isn't a repository or (more
@@ -97,7 +98,9 @@ export async function getIndexChanges(
     result = await git(
       [...args, NullTreeSHA],
       repository.path,
-      'getIndexChanges'
+      'getIndexChanges',
+      {},
+      repository.codespace
     )
   }
 

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -126,7 +126,10 @@ export async function getCommitDiff(
   const { output } = await spawnAndComplete(
     args,
     repository.path,
-    'getCommitDiff'
+    'getCommitDiff',
+    undefined,
+    undefined,
+    repository.codespace
   )
 
   return buildDiff(output, repository, file, commitish)
@@ -187,7 +190,9 @@ export async function getWorkingDirectoryDiff(
     args,
     repository.path,
     'getWorkingDirectoryDiff',
-    successExitCodes
+    successExitCodes,
+    undefined,
+    repository.codespace
   )
   const lineEndingsChange = parseLineEndingsWarning(error)
 
@@ -454,7 +459,10 @@ export async function getBinaryPaths(
   const { output } = await spawnAndComplete(
     ['diff', '--numstat', '-z', ref],
     repository.path,
-    'getBinaryPaths'
+    'getBinaryPaths',
+    undefined,
+    undefined,
+    repository.codespace
   )
   const captures = getCaptures(output.toString('utf8'), binaryListRegex)
   if (captures.length === 0) {

--- a/app/src/lib/git/fetch.ts
+++ b/app/src/lib/git/fetch.ts
@@ -18,7 +18,7 @@ async function getFetchArgs(
   const networkArguments = await gitNetworkArguments(repository, account)
 
   if (enableRecurseSubmodulesFlag()) {
-    return progressCallback != null
+    return progressCallback
       ? [
           ...networkArguments,
           'fetch',
@@ -35,7 +35,7 @@ async function getFetchArgs(
           remote,
         ]
   } else {
-    return progressCallback != null
+    return progressCallback
       ? [...networkArguments, 'fetch', '--progress', '--prune', remote]
       : [...networkArguments, 'fetch', '--prune', remote]
   }
@@ -113,7 +113,8 @@ export async function fetch(
     return git(args, repository.path, 'fetch', {
       ...opts,
       env: merge(opts.env, env),
-    })
+    },
+    repository.codespace)
   })
 }
 
@@ -136,7 +137,8 @@ export async function fetchRefspec(
     return git(args, repository.path, 'fetchRefspec', {
       ...options,
       env,
-    })
+    },
+    repository.codespace)
   })
 }
 
@@ -178,6 +180,7 @@ export async function fastForwardBranches(
     ],
     repository.path,
     'fastForwardBranches',
-    opts
+    opts,
+    repository.codespace
   )
 }

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -35,7 +35,8 @@ export async function getBranches(
     ['for-each-ref', ...formatArgs, ...prefixes],
     repository.path,
     'getBranches',
-    { expectedErrors: new Set([GitError.NotAGitRepository]) }
+    { expectedErrors: new Set([GitError.NotAGitRepository]) },
+    repository.codespace
   )
 
   if (result.gitError === GitError.NotAGitRepository) {
@@ -91,7 +92,8 @@ export async function getBranchesDifferingFromUpstream(
     ['for-each-ref', ...formatArgs, ...prefixes],
     repository.path,
     'getBranchesDifferingFromUpstream',
-    { expectedErrors: new Set([GitError.NotAGitRepository]) }
+    { expectedErrors: new Set([GitError.NotAGitRepository]) },
+    repository.codespace
   )
 
   if (result.gitError === GitError.NotAGitRepository) {

--- a/app/src/lib/git/format-patch.ts
+++ b/app/src/lib/git/format-patch.ts
@@ -19,7 +19,10 @@ export async function formatPatch(
   const { output } = await spawnAndComplete(
     ['format-patch', '--unified=1', '--minimal', '--stdout', range],
     repository.path,
-    'formatPatch'
+    'formatPatch',
+    undefined,
+    undefined,
+    repository.codespace
   )
   return output.toString('utf8')
 }

--- a/app/src/lib/git/interpret-trailers.ts
+++ b/app/src/lib/git/interpret-trailers.ts
@@ -107,7 +107,8 @@ export async function parseTrailers(
     'parseTrailers',
     {
       stdin: commitMessage,
-    }
+    },
+    repository.codespace
   )
 
   const trailers = result.stdout
@@ -167,7 +168,8 @@ export async function mergeTrailers(
 
   const result = await git(args, repository.path, 'mergeTrailers', {
     stdin: commitMessage,
-  })
+  },
+  repository.codespace)
 
   return result.stdout
 }

--- a/app/src/lib/git/lfs.ts
+++ b/app/src/lib/git/lfs.ts
@@ -2,13 +2,13 @@ import { git } from './core'
 import { Repository } from '../../models/repository'
 
 /** Install the global LFS filters. */
-export async function installGlobalLFSFilters(force: boolean): Promise<void> {
+export async function installGlobalLFSFilters(force: boolean, remote = false): Promise<void> {
   const args = ['lfs', 'install', '--skip-repo']
   if (force) {
     args.push('--force')
   }
 
-  await git(args, __dirname, 'installGlobalLFSFilter')
+  await git(args, __dirname, 'installGlobalLFSFilter', {}, remote)
 }
 
 /** Install LFS hooks in the repository. */
@@ -21,7 +21,7 @@ export async function installLFSHooks(
     args.push('--force')
   }
 
-  await git(args, repository.path, 'installLFSHooks')
+  await git(args, repository.path, 'installLFSHooks', {}, repository.codespace)
 }
 
 /** Is the repository configured to track any paths with LFS? */
@@ -31,7 +31,8 @@ export async function isUsingLFS(repository: Repository): Promise<boolean> {
   }
   const result = await git(['lfs', 'track'], repository.path, 'isUsingLFS', {
     env,
-  })
+  },
+  repository.codespace)
   return result.stdout.length > 0
 }
 
@@ -51,7 +52,9 @@ export async function isTrackedByLFS(
   const { stdout } = await git(
     ['check-attr', 'filter', path],
     repository.path,
-    'checkAttrForLFS'
+    'checkAttrForLFS',
+    {},
+    repository.codespace
   )
 
   // "git check-attr -a" will output every filter it can find in .gitattributes

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -103,7 +103,8 @@ export async function getCommits(
   )
   const result = await git(args, repository.path, 'getCommits', {
     successExitCodes: new Set([0, 128]),
-  })
+  },
+  repository.codespace)
 
   // if the repository has an unborn HEAD, return an empty history of commits
   if (result.exitCode === 128) {
@@ -154,7 +155,7 @@ export async function getChangedFiles(
     '-z',
     '--',
   ]
-  const result = await git(args, repository.path, 'getChangedFiles')
+  const result = await git(args, repository.path, 'getChangedFiles', {}, repository.codespace)
 
   return parseChangedFiles(result.stdout, sha)
 }

--- a/app/src/lib/git/merge.ts
+++ b/app/src/lib/git/merge.ts
@@ -35,7 +35,8 @@ export async function merge(
     'merge',
     {
       expectedErrors: new Set([GitError.MergeConflicts]),
-    }
+    },
+    repository.codespace
   )
 
   if (exitCode !== 0) {
@@ -69,7 +70,8 @@ export async function getMergeBase(
       // - 128 is returned if a ref cannot be found
       //   "warning: ignoring broken ref refs/remotes/origin/main."
       successExitCodes: new Set([0, 1, 128]),
-    }
+    },
+    repository.codespace
   )
 
   if (process.exitCode === 1 || process.exitCode === 128) {
@@ -104,7 +106,10 @@ export async function mergeTree(
   const result = await spawnAndComplete(
     ['merge-tree', mergeBase, ours.tip.sha, theirs.tip.sha],
     repository.path,
-    'mergeTree'
+    'mergeTree',
+    undefined,
+    undefined,
+    repository.codespace
   )
 
   const output = result.output.toString()
@@ -123,7 +128,7 @@ export async function mergeTree(
  * @param repository where to abort the merge
  */
 export async function abortMerge(repository: Repository): Promise<void> {
-  await git(['merge', '--abort'], repository.path, 'abortMerge')
+  await git(['merge', '--abort'], repository.path, 'abortMerge', {}, repository.codespace)
 }
 
 /**

--- a/app/src/lib/git/pull.ts
+++ b/app/src/lib/git/pull.ts
@@ -111,7 +111,8 @@ export async function pull(
       return git(args, repository.path, 'pull', {
         ...opts,
         env: merge(opts.env, env),
-      })
+      },
+      repository.codespace)
     }
   )
 

--- a/app/src/lib/git/push.ts
+++ b/app/src/lib/git/push.ts
@@ -127,7 +127,8 @@ export async function push(
       return git(args, repository.path, 'push', {
         ...opts,
         env: merge(opts.env, env),
-      })
+      },
+      repository.codespace)
     }
   )
 

--- a/app/src/lib/git/rebase.ts
+++ b/app/src/lib/git/rebase.ts
@@ -390,7 +390,8 @@ export async function rebase(
     [...gitRebaseArguments(), 'rebase', baseBranch.name, targetBranch.name],
     repository.path,
     'rebase',
-    options
+    options,
+    repository.codespace
   )
 
   return parseRebaseResult(result)
@@ -398,7 +399,7 @@ export async function rebase(
 
 /** Abandon the current rebase operation */
 export async function abortRebase(repository: Repository) {
-  await git(['rebase', '--abort'], repository.path, 'abortRebase')
+  await git(['rebase', '--abort'], repository.path, 'abortRebase', {}, repository.codespace)
 }
 
 function parseRebaseResult(result: IGitResult): RebaseResult {
@@ -506,7 +507,8 @@ export async function continueRebase(
       ['rebase', '--skip'],
       repository.path,
       'continueRebaseSkipCurrentCommit',
-      options
+      options,
+      repository.codespace
     )
 
     return parseRebaseResult(result)
@@ -516,7 +518,8 @@ export async function continueRebase(
     ['rebase', '--continue'],
     repository.path,
     'continueRebase',
-    options
+    options,
+    repository.codespace
   )
 
   return parseRebaseResult(result)
@@ -582,7 +585,8 @@ export async function rebaseInteractive(
     ],
     repository.path,
     action,
-    options
+    options,
+    repository.codespace
   )
 
   return parseRebaseResult(result)

--- a/app/src/lib/git/reflog.ts
+++ b/app/src/lib/git/reflog.ts
@@ -28,7 +28,8 @@ export async function getRecentBranches(
     ],
     repository.path,
     'getRecentBranches',
-    { successExitCodes: new Set([0, 128]) }
+    { successExitCodes: new Set([0, 128]) },
+    repository.codespace
   )
 
   if (result.exitCode === 128) {
@@ -96,7 +97,8 @@ export async function getBranchCheckouts(
     ],
     repository.path,
     'getCheckoutsAfterDate',
-    { successExitCodes: new Set([0, 128]) }
+    { successExitCodes: new Set([0, 128]) },
+    repository.codespace
   )
 
   const checkouts = new Map<string, Date>()

--- a/app/src/lib/git/refs.ts
+++ b/app/src/lib/git/refs.ts
@@ -52,7 +52,8 @@ export async function getSymbolicRef(
       //  - 128 is the generic error code that Git returns when it can't find
       //    something
       successExitCodes: new Set([0, 1, 128]),
-    }
+    },
+    repository.codespace
   )
 
   if (result.exitCode === 1 || result.exitCode === 128) {

--- a/app/src/lib/git/remote.ts
+++ b/app/src/lib/git/remote.ts
@@ -12,7 +12,8 @@ export async function getRemotes(
 ): Promise<ReadonlyArray<IRemote>> {
   const result = await git(['remote', '-v'], repository.path, 'getRemotes', {
     expectedErrors: new Set([GitError.NotAGitRepository]),
-  })
+  },
+  repository.codespace)
 
   if (result.gitError === GitError.NotAGitRepository) {
     return []
@@ -34,7 +35,7 @@ export async function addRemote(
   name: string,
   url: string
 ): Promise<IRemote> {
-  await git(['remote', 'add', name, url], repository.path, 'addRemote')
+  await git(['remote', 'add', name, url], repository.path, 'addRemote', {}, repository.codespace)
 
   return { url, name }
 }
@@ -52,7 +53,8 @@ export async function removeRemote(
     ['remote', 'remove', name],
     repository.path,
     'removeRemote',
-    options
+    options,
+    repository.codespace
   )
 }
 
@@ -62,7 +64,7 @@ export async function setRemoteURL(
   name: string,
   url: string
 ): Promise<true> {
-  await git(['remote', 'set-url', name, url], repository.path, 'setRemoteURL')
+  await git(['remote', 'set-url', name, url], repository.path, 'setRemoteURL', {}, repository.codespace)
   return true
 }
 
@@ -79,7 +81,8 @@ export async function getRemoteURL(
     ['remote', 'get-url', name],
     repository.path,
     'getRemoteURL',
-    { successExitCodes: new Set([0, 128]) }
+    { successExitCodes: new Set([0, 128]) },
+    repository.codespace
   )
 
   if (result.exitCode !== 0) {

--- a/app/src/lib/git/reset.ts
+++ b/app/src/lib/git/reset.ts
@@ -44,7 +44,7 @@ export async function reset(
   ref: string
 ): Promise<true> {
   const args = resetModeToArgs(mode, ref)
-  await git(args, repository.path, 'reset')
+  await git(args, repository.path, 'reset', {}, repository.codespace)
   return true
 }
 
@@ -87,15 +87,16 @@ export async function resetPaths(
     const args = [...baseArgs, '--stdin', '-z', '--']
     await git(args, repository.path, 'resetPaths', {
       stdin: paths.join('\0'),
-    })
+    },
+    repository.codespace)
   } else {
     const args = [...baseArgs, '--', ...paths]
-    await git(args, repository.path, 'resetPaths')
+    await git(args, repository.path, 'resetPaths', {}, repository.codespace)
   }
 }
 
 /** Unstage all paths. */
 export async function unstageAll(repository: Repository): Promise<true> {
-  await git(['reset', '--', '.'], repository.path, 'unstageAll')
+  await git(['reset', '--', '.'], repository.path, 'unstageAll', {}, repository.codespace)
   return true
 }

--- a/app/src/lib/git/rev-list.ts
+++ b/app/src/lib/git/rev-list.ts
@@ -61,7 +61,8 @@ export async function getAheadBehind(
   const args = ['rev-list', '--left-right', '--count', range, '--']
   const result = await git(args, repository.path, 'getAheadBehind', {
     expectedErrors: new Set([GitError.BadRevision]),
-  })
+  },
+  repository.codespace)
 
   // This means one of the refs (most likely the upstream branch) no longer
   // exists. In that case we can't be ahead/behind at all.
@@ -154,7 +155,7 @@ export async function getCommitsInRange(
     expectedErrors: new Set<GitError>([GitError.BadRevision]),
   }
 
-  const result = await git(args, repository.path, 'getCommitsInRange', options)
+  const result = await git(args, repository.path, 'getCommitsInRange', options, repository.codespace)
 
   if (result.gitError === GitError.BadRevision) {
     return null

--- a/app/src/lib/git/rev-parse.ts
+++ b/app/src/lib/git/rev-parse.ts
@@ -12,7 +12,8 @@ import { RepositoryDoesNotExistErrorCode } from 'dugite'
  * @returns null if the path provided doesn't reside within a Git repository.
  */
 export async function getTopLevelWorkingDirectory(
-  path: string
+  path: string,
+  remote = false
 ): Promise<string | null> {
   let result
 
@@ -26,7 +27,8 @@ export async function getTopLevelWorkingDirectory(
       'getTopLevelWorkingDirectory',
       {
         successExitCodes: new Set([0, 128]),
-      }
+      },
+      remote
     )
   } catch (err) {
     if (err.code === RepositoryDoesNotExistErrorCode) {
@@ -59,12 +61,14 @@ export async function getTopLevelWorkingDirectory(
  *
  * @returns true if the path contains a bare Git repository. Returns false if it is not bare or is not a Git repository.
  */
-export async function isBareRepository(path: string): Promise<boolean> {
+export async function isBareRepository(path: string, remote = false): Promise<boolean> {
   try {
     const result = await git(
       ['rev-parse', '--is-bare-repository'],
       path,
-      'isBareRepository'
+      'isBareRepository',
+      {},
+      remote
     )
     return result.stdout.trim() === 'true'
   } catch (e) {
@@ -77,6 +81,6 @@ export async function isBareRepository(path: string): Promise<boolean> {
 }
 
 /** Is the path a git repository? */
-export async function isGitRepository(path: string): Promise<boolean> {
-  return (await getTopLevelWorkingDirectory(path)) !== null
+export async function isGitRepository(path: string, remote = false): Promise<boolean> {
+  return (await getTopLevelWorkingDirectory(path, remote)) !== null
 }

--- a/app/src/lib/git/revert.ts
+++ b/app/src/lib/git/revert.ts
@@ -57,7 +57,8 @@ export async function revertCommit(
       return git(args, repository.path, 'revert', {
         ...opts,
         env: merge(opts.env, env),
-      })
+      },
+      repository.codespace)
     }
   )
 }

--- a/app/src/lib/git/rm.ts
+++ b/app/src/lib/git/rm.ts
@@ -16,7 +16,9 @@ export async function unstageAllFiles(repository: Repository): Promise<void> {
     //          which will block this
     ['rm', '--cached', '-r', '-f', '.'],
     repository.path,
-    'unstageAllFiles'
+    'unstageAllFiles',
+    {},
+    repository.codespace
   )
 }
 
@@ -27,5 +29,5 @@ export async function removeConflictedFile(
   repository: Repository,
   file: WorkingDirectoryFileChange
 ) {
-  await git(['rm', '--', file.path], repository.path, 'removeConflictedFile')
+  await git(['rm', '--', file.path], repository.path, 'removeConflictedFile', {}, repository.codespace)
 }

--- a/app/src/lib/git/show.ts
+++ b/app/src/lib/git/show.ts
@@ -41,7 +41,7 @@ export async function getBlobContents(
     processCallback: setBinaryEncoding,
   }
 
-  const blobContents = await git(args, repository.path, 'getBlobContents', opts)
+  const blobContents = await git(args, repository.path, 'getBlobContents', opts, repository.codespace)
 
   return Buffer.from(blobContents.stdout, 'binary')
 }
@@ -83,7 +83,8 @@ export async function getPartialBlobContents(
     repository.path,
     'getPartialBlobContents',
     successExitCodes,
-    length
+    length,
+    repository.codespace
   )
 
   return output

--- a/app/src/lib/git/spawn.ts
+++ b/app/src/lib/git/spawn.ts
@@ -28,14 +28,15 @@ export function spawnAndComplete(
   path: string,
   name: string,
   successExitCodes?: Set<number>,
-  stdOutMaxLength?: number
+  stdOutMaxLength?: number,
+  remote = false
 ): Promise<ProcessOutput> {
   const commandName = `${name}: git ${args.join(' ')}`
   return GitPerf.measure(
     commandName,
     () =>
       new Promise<ProcessOutput>((resolve, _) => {
-        GitProcess.exec(args, path).then((result) => {
+        GitProcess.exec(args, path, {}, remote).then((result: any) => {
           resolve({
             output: Buffer.from(result.stdout),
             error: Buffer.from(result.stderr),

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -51,7 +51,8 @@ export async function getStashes(repository: Repository): Promise<StashResult> {
     'getStashEntries',
     {
       successExitCodes: new Set([0, 128]),
-    }
+    },
+    repository.codespace
   )
 
   // There's no refs/stashes reflog in the repository or it's not
@@ -135,7 +136,8 @@ export async function createDesktopStashEntry(
 
   const result = await git(args, repository.path, 'createStashEntry', {
     successExitCodes: new Set<number>([0, 1]),
-  })
+  },
+  repository.codespace)
 
   if (result.exitCode === 1) {
     // search for any line starting with `error:` -  /m here to ensure this is
@@ -182,7 +184,7 @@ export async function dropDesktopStashEntry(
 
   if (entryToDelete !== null) {
     const args = ['stash', 'drop', entryToDelete.name]
-    await git(args, repository.path, 'dropStashEntry')
+    await git(args, repository.path, 'dropStashEntry', {}, repository.codespace)
   }
 }
 
@@ -208,7 +210,8 @@ export async function popStashEntry(
     const result = await git(args, repository.path, 'popStashEntry', {
       expectedErrors,
       successExitCodes,
-    })
+    },
+    repository.codespace)
 
     // popping a stashes that create conflicts in the working directory
     // report an exit code of `1` and are not dropped after being applied.
@@ -283,7 +286,8 @@ async function getChangedFilesWithinStash(repository: Repository, sha: string) {
     // because there weren't any untracked files,
     // and that's okay!
     successExitCodes: new Set([0, 128]),
-  })
+  },
+  repository.codespace)
   if (result.exitCode === 0 && result.stdout.length > 0) {
     return parseChangedFiles(result.stdout, sha)
   }

--- a/app/src/lib/git/status.ts
+++ b/app/src/lib/git/status.ts
@@ -177,8 +177,12 @@ export async function getStatus(
     args,
     repository.path,
     'getStatus',
-    new Set([0, 128])
+    new Set([0, 128]),
+    undefined,
+    repository.codespace
   )
+
+  log.info('status is checking up on us')
 
   if (result.exitCode === 128) {
     log.debug(
@@ -234,6 +238,8 @@ export async function getStatus(
   const workingDirectory = WorkingDirectoryStatus.fromFiles([...files.values()])
 
   const isCherryPickingHeadFound = await isCherryPickHeadFound(repository)
+
+  log.info('status says we still exist')
 
   return {
     currentBranch,
@@ -341,7 +347,8 @@ function parseStatusHeader(results: IStatusHeadersData, header: IStatusHeader) {
 
 async function getMergeConflictDetails(repository: Repository) {
   const conflictCountsByPath = await getFilesWithConflictMarkers(
-    repository.path
+    repository.path,
+    repository.codespace
   )
   const binaryFilePaths = await getBinaryPaths(repository, 'MERGE_HEAD')
   return {
@@ -352,7 +359,8 @@ async function getMergeConflictDetails(repository: Repository) {
 
 async function getRebaseConflictDetails(repository: Repository) {
   const conflictCountsByPath = await getFilesWithConflictMarkers(
-    repository.path
+    repository.path,
+    repository.codespace
   )
   const binaryFilePaths = await getBinaryPaths(repository, 'REBASE_HEAD')
   return {
@@ -367,7 +375,8 @@ async function getRebaseConflictDetails(repository: Repository) {
  */
 async function getWorkingDirectoryConflictDetails(repository: Repository) {
   const conflictCountsByPath = await getFilesWithConflictMarkers(
-    repository.path
+    repository.path,
+    repository.codespace
   )
   let binaryFilePaths: ReadonlyArray<string> = []
   try {

--- a/app/src/lib/git/submodule.ts
+++ b/app/src/lib/git/submodule.ts
@@ -27,7 +27,8 @@ export async function listSubmodules(
     'listSubmodules',
     {
       successExitCodes: new Set([0, 128]),
-    }
+    },
+    repository.codespace
   )
 
   if (result.exitCode === 128) {
@@ -87,6 +88,8 @@ export async function resetSubmodulePaths(
   await git(
     ['submodule', 'update', '--recursive', '--force', '--', ...paths],
     repository.path,
-    'updateSubmodule'
+    'updateSubmodule',
+    {},
+    repository.codespace
   )
 }

--- a/app/src/lib/git/tag.ts
+++ b/app/src/lib/git/tag.ts
@@ -18,7 +18,7 @@ export async function createTag(
 ): Promise<void> {
   const args = ['tag', '-a', '-m', '', name, targetCommitSha]
 
-  await git(args, repository.path, 'createTag')
+  await git(args, repository.path, 'createTag', {}, repository.codespace)
 }
 
 /**
@@ -33,7 +33,7 @@ export async function deleteTag(
 ): Promise<void> {
   const args = ['tag', '-d', name]
 
-  await git(args, repository.path, 'deleteTag')
+  await git(args, repository.path, 'deleteTag', {}, repository.codespace)
 }
 
 /**
@@ -48,7 +48,8 @@ export async function getAllTags(
 
   const tags = await git(args, repository.path, 'getAllTags', {
     successExitCodes: new Set([0, 1]), // when there are no tags, git exits with 1.
-  })
+  },
+  repository.codespace)
 
   const tagsArray: Array<[string, string]> = tags.stdout
     .split('\n')
@@ -110,7 +111,8 @@ export async function fetchTagsToPush(
       return git(args, repository.path, 'fetchTagsToPush', {
         env,
         successExitCodes: new Set([0, 1, 128]),
-      })
+      },
+      repository.codespace)
     }
   )
 

--- a/app/src/lib/git/update-index.ts
+++ b/app/src/lib/git/update-index.ts
@@ -95,7 +95,8 @@ async function updateIndex(
 
   await git(args, repository.path, 'updateIndex', {
     stdin: paths.join('\0'),
-  })
+  },
+  repository.codespace)
 }
 
 /**

--- a/app/src/lib/git/update-ref.ts
+++ b/app/src/lib/git/update-ref.ts
@@ -22,7 +22,9 @@ export async function updateRef(
   await git(
     ['update-ref', ref, newValue, oldValue, '-m', reason],
     repository.path,
-    'updateRef'
+    'updateRef',
+    {},
+    repository.codespace
   )
 }
 
@@ -46,5 +48,5 @@ export async function deleteRef(
     args.push('-m', reason)
   }
 
-  await git(args, repository.path, 'deleteRef')
+  await git(args, repository.path, 'deleteRef', {}, repository.codespace)
 }

--- a/app/src/lib/git/var.ts
+++ b/app/src/lib/git/var.ts
@@ -26,7 +26,8 @@ export async function getAuthorIdentity(
     'getAuthorIdentity',
     {
       successExitCodes: new Set([0, 128]),
-    }
+    },
+    repository.codespace
   )
 
   // If user.user.useconfigonly is set and no user.name or user.email

--- a/app/src/lib/git/worktree.ts
+++ b/app/src/lib/git/worktree.ts
@@ -17,7 +17,9 @@ export async function listWorkTrees(
   const result = await git(
     ['worktree', 'list', '--porcelain'],
     repository.path,
-    'listWorkTrees'
+    'listWorkTrees',
+    {},
+    repository.codespace
   )
 
   const worktrees = new Array<LinkedWorkTree>()
@@ -54,7 +56,9 @@ export async function createTemporaryWorkTree(
   await git(
     ['worktree', 'add', '-f', workTreePath, commit],
     repository.path,
-    'addWorkTree'
+    'addWorkTree',
+    {},
+    repository.codespace
   )
   // Because Git doesn't give enough information from stdout for the previous
   // Git call, this function enumerates the available worktrees to find the
@@ -83,7 +87,9 @@ export async function destroyWorkTree(
   await git(
     ['worktree', 'remove', '-f', workTree.path],
     repository.path,
-    'removeWorkTree'
+    'removeWorkTree',
+    {},
+    repository.codespace
   )
   return true
 }

--- a/app/src/lib/stats/stats-store.ts
+++ b/app/src/lib/stats/stats-store.ts
@@ -1044,6 +1044,10 @@ export class StatsStore implements IStatsStore {
     createLocalStorageTimestamp(FirstRepositoryAddedAtKey)
   }
 
+  public recordAddCodespaceRepository() {
+    createLocalStorageTimestamp(FirstRepositoryAddedAtKey)
+  }
+
   public recordCloneRepository() {
     createLocalStorageTimestamp(FirstRepositoryClonedAtKey)
   }

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -135,7 +135,8 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.missing,
       enableRepositoryAliases() ? repo.alias : null,
       repo.workflowPreferences,
-      repo.isTutorialRepository
+      repo.isTutorialRepository,
+      repo.codespace
     )
   }
 
@@ -213,7 +214,7 @@ export class RepositoriesStore extends TypedBaseStore<
    *
    * If a repository already exists with that path, it will be returned instead.
    */
-  public async addRepository(path: string): Promise<Repository> {
+  public async addRepository(path: string, codespace=false): Promise<Repository> {
     const repository = await this.db.transaction(
       'rw',
       this.db.repositories,
@@ -232,6 +233,7 @@ export class RepositoriesStore extends TypedBaseStore<
           missing: false,
           lastStashCheckDate: null,
           alias: null,
+          codespace: true
         }
         const id = await this.db.repositories.add(dbRepo)
         return this.toRepository({ id, ...dbRepo })

--- a/app/src/models/cloning-repository.ts
+++ b/app/src/models/cloning-repository.ts
@@ -5,6 +5,7 @@ let CloningRepositoryID = 1
 /** A repository which is currently being cloned. */
 export class CloningRepository {
   public readonly id = CloningRepositoryID++
+  public readonly codespace = false
 
   public constructor(
     public readonly path: string,

--- a/app/src/models/popup.ts
+++ b/app/src/models/popup.ts
@@ -28,6 +28,7 @@ export enum PopupType {
   MergeBranch,
   RepositorySettings,
   AddRepository,
+  AddCodespaceRepository,
   CreateRepository,
   CloneRepository,
   CreateBranch,
@@ -116,6 +117,7 @@ export type Popup =
       initialSelectedTab?: RepositorySettingsTab
     }
   | { type: PopupType.AddRepository; path?: string }
+  | { type: PopupType.AddCodespaceRepository; path?: string }
   | { type: PopupType.CreateRepository; path?: string }
   | {
       type: PopupType.CloneRepository

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -58,7 +58,8 @@ export class Repository {
      * onboarding flow. Tutorial repositories trigger a tutorial user experience
      * which introduces new users to some core concepts of Git and GitHub.
      */
-    public readonly isTutorialRepository: boolean = false
+    public readonly isTutorialRepository: boolean = false,
+    public readonly codespace: boolean = false
   ) {
     this.mainWorkTree = { path }
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
@@ -70,7 +71,8 @@ export class Repository {
       this.missing,
       this.alias,
       this.workflowPreferences.forkContributionTarget,
-      this.isTutorialRepository
+      this.isTutorialRepository,
+      this.codespace
     )
   }
 

--- a/app/src/ui/add-repository/add-codespace-repository.tsx
+++ b/app/src/ui/add-repository/add-codespace-repository.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react'
+
+import { Dispatcher } from '../dispatcher'
+import { TextBox } from '../lib/text-box'
+import { Row } from '../lib/row'
+import { Dialog, DialogContent, DialogFooter } from '../dialog'
+import { OkCancelButtonGroup } from '../dialog/ok-cancel-button-group'
+
+interface IAddCodespaceRepositoryProps {
+  readonly dispatcher: Dispatcher
+  readonly onDismissed: () => void
+
+  /** An optional path to prefill the path text box with.
+   * Defaults to the empty string if not defined.
+   */
+  readonly path?: string
+}
+
+interface IAddCodespaceRepositoryState {
+  readonly path: string
+}
+
+/** The component for adding an existing local repository. */
+export class AddCodespaceRepository extends React.Component<
+  IAddCodespaceRepositoryProps,
+  IAddCodespaceRepositoryState
+> {
+  public constructor(props: IAddCodespaceRepositoryProps) {
+    super(props)
+
+    const path = this.props.path ? this.props.path : ''
+
+    this.state = {
+      path,
+    }
+  }
+
+  public render() {
+    const disabled =
+      this.state.path.length === 0
+
+    return (
+      <Dialog
+        id="add-existing-repository"
+        title='Add codespace repository'
+        onSubmit={this.addRepository}
+        onDismissed={this.props.onDismissed}
+      >
+        <DialogContent>
+          <Row>
+            <TextBox
+              value={this.state.path}
+              label='Remote path'
+              placeholder="repository path"
+              onValueChanged={this.onPathChanged}
+            />
+          </Row>
+        </DialogContent>
+
+        <DialogFooter>
+          <OkCancelButtonGroup
+            okButtonText={__DARWIN__ ? 'Add Repository' : 'Add repository'}
+            okButtonDisabled={disabled}
+          />
+        </DialogFooter>
+      </Dialog>
+    )
+  }
+
+  private onPathChanged = async (path: string) => {
+    this.setState({ path })
+  }
+
+  private addRepository = async () => {
+    this.props.onDismissed()
+    const { dispatcher } = this.props
+
+    const repositories = await dispatcher.addRepositories([this.state.path], true)
+
+    if (repositories.length > 0) {
+      dispatcher.selectRepository(repositories[0])
+      dispatcher.recordAddCodespaceRepository()
+    }
+  }
+}

--- a/app/src/ui/add-repository/index.tsx
+++ b/app/src/ui/add-repository/index.tsx
@@ -1,2 +1,3 @@
 export * from './add-existing-repository'
+export * from './add-codespace-repository'
 export * from './create-repository'

--- a/app/src/ui/app.tsx
+++ b/app/src/ui/app.tsx
@@ -66,7 +66,7 @@ import { Merge } from './merge-branch'
 import { RepositorySettings } from './repository-settings'
 import { AppError } from './app-error'
 import { MissingRepository } from './missing-repository'
-import { AddExistingRepository, CreateRepository } from './add-repository'
+import { AddExistingRepository, AddCodespaceRepository, CreateRepository } from './add-repository'
 import { CloneRepository } from './clone-repository'
 import { CreateBranch } from './create-branch'
 import { SignIn } from './sign-in'
@@ -325,7 +325,9 @@ export class App extends React.Component<IAppProps, IAppState> {
     this.props.dispatcher.reportStats()
     setInterval(() => this.props.dispatcher.reportStats(), SendStatsInterval)
 
-    this.props.dispatcher.installGlobalLFSFilters(false)
+    const selectedRepository = this.props.appStore.getSelectedRepository()
+
+    this.props.dispatcher.installGlobalLFSFilters(false, selectedRepository?.codespace)
 
     setInterval(() => this.checkForUpdates(true), UpdateCheckInterval)
     this.checkForUpdates(true)
@@ -1498,6 +1500,15 @@ export class App extends React.Component<IAppProps, IAppState> {
             path={popup.path}
           />
         )
+      case PopupType.AddCodespaceRepository:
+        return (
+          <AddCodespaceRepository
+            key="add-codespace-repository"
+            onDismissed={onPopupDismissedFn}
+            dispatcher={this.props.dispatcher}
+            path={popup.path}
+          />
+        )
       case PopupType.CreateRepository:
         return (
           <CreateRepository
@@ -2293,7 +2304,8 @@ export class App extends React.Component<IAppProps, IAppState> {
   }
 
   private updateExistingLFSFilters = () => {
-    this.props.dispatcher.installGlobalLFSFilters(true)
+    const selectedRepository = this.props.appStore.getSelectedRepository()
+    this.props.dispatcher.installGlobalLFSFilters(true, selectedRepository?.codespace)
   }
 
   private initializeLFS = (repositories: ReadonlyArray<Repository>) => {

--- a/app/src/ui/diff/syntax-highlighting/index.ts
+++ b/app/src/ui/diff/syntax-highlighting/index.ts
@@ -118,7 +118,7 @@ export async function getFileContents(
       : Promise.resolve(null)
 
   const newContentsPromise =
-    enableTextDiffExpansion() || lineFilters.newLineFilter.length
+    !repo.codespace && (enableTextDiffExpansion() || lineFilters.newLineFilter.length)
       ? getNewFileContent(repo, file)
       : Promise.resolve(null)
 

--- a/app/src/ui/dispatcher/dispatcher.ts
+++ b/app/src/ui/dispatcher/dispatcher.ts
@@ -152,9 +152,10 @@ export class Dispatcher {
    * this will post an error to that affect.
    */
   public addRepositories(
-    paths: ReadonlyArray<string>
+    paths: ReadonlyArray<string>,
+    codespace = false
   ): Promise<ReadonlyArray<Repository>> {
-    return this.appStore._addRepositories(paths)
+    return this.appStore._addRepositories(paths, codespace)
   }
 
   /**
@@ -1987,8 +1988,8 @@ export class Dispatcher {
   }
 
   /** Install the global Git LFS filters. */
-  public installGlobalLFSFilters(force: boolean): Promise<void> {
-    return this.appStore._installGlobalLFSFilters(force)
+  public installGlobalLFSFilters(force: boolean, remote = false): Promise<void> {
+    return this.appStore._installGlobalLFSFilters(force, remote)
   }
 
   /** Install the LFS filters */
@@ -2281,6 +2282,10 @@ export class Dispatcher {
 
   public recordAddExistingRepository() {
     this.statsStore.recordAddExistingRepository()
+  }
+
+  public recordAddCodespaceRepository() {
+    this.statsStore.recordAddCodespaceRepository()
   }
 
   /**

--- a/app/src/ui/dispatcher/error-handlers.ts
+++ b/app/src/ui/dispatcher/error-handlers.ts
@@ -89,6 +89,8 @@ export async function missingRepositoryHandler(
   error: Error,
   dispatcher: Dispatcher
 ): Promise<Error | null> {
+  log.error(error.message)
+
   const e = asErrorWithMetadata(error)
   if (!e) {
     return error

--- a/app/src/ui/repositories-list/repositories-list.tsx
+++ b/app/src/ui/repositories-list/repositories-list.tsx
@@ -303,6 +303,10 @@ export class RepositoriesList extends React.Component<
           : 'Add existing repository…',
         action: this.onAddExistingRepository,
       },
+      {
+        label: 'Add Codespace Repository...',
+        action: this.onAddCodespaceRepository,
+      },
     ]
 
     showContextualMenu(items)
@@ -317,6 +321,10 @@ export class RepositoriesList extends React.Component<
 
   private onAddExistingRepository = () => {
     this.props.dispatcher.showPopup({ type: PopupType.AddRepository })
+  }
+
+  private onAddCodespaceRepository = () => {
+    this.props.dispatcher.showPopup({ type: PopupType.AddCodespaceRepository })
   }
 
   private onCreateNewRepository = () => {


### PR DESCRIPTION
The goal is to leverage the work in https://github.com/bradshjg/dugite/pull/1 to allow remote execution (e.g. Desktop running locally interacting with a git repository living in a Codespace).

With that branch of dugite, setting`DUGITE_REMOTE_URL` when starting Desktop to ensure all `git` operations are sent over the network to be executed.

To support that, this changes Desktop to prefer the `GitProcess.exec` which is currently the only one supporting remote execution.
