### PR TITLE
Beta SSH fixes

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "productName": "GitHub Desktop (Experimental)",
   "bundleID": "com.github.GitHubClient",
   "companyName": "GitHub, Inc.",
-  "version": "3.1.2-beta1-virtual",
+  "version": "3.1.2-beta2-virtual",
   "main": "./main.js",
   "repository": {
     "type": "git",

--- a/app/src/lib/databases/repositories-database.ts
+++ b/app/src/lib/databases/repositories-database.ts
@@ -65,7 +65,6 @@ export interface IDatabaseRepository {
    * of Git and GitHub.
    */
   readonly isTutorialRepository?: boolean
-  readonly isSSHRepository?: boolean
 }
 
 /**

--- a/app/src/lib/fs/index.ts
+++ b/app/src/lib/fs/index.ts
@@ -3,10 +3,6 @@ import * as FSE from 'fs-extra'
 import { Repository } from '../../models/repository'
 import { remotePathExists, remoteReadFile, remoteReadPartialFile } from '../virtual/fs/core'
 
-const isSSHRepo = (repository: Repository): Boolean => {
-  return repository.path.startsWith('ssh::')
-}
-
 const sshPath = (path: string) => {
   // HACK HACK HACK the path is probably something like ssh::someHost::/path/to/file...but maybe it's /path/to/file
   // so we handle both cases by splitting on :: and taking the last element
@@ -14,7 +10,7 @@ const sshPath = (path: string) => {
 }
 
 export const repoPathExists = (repository: Repository, path: string): Promise<boolean> => {
-  if (isSSHRepo(repository)) {
+  if (repository.isSSHRepository) {
     path = sshPath(path)
     return remotePathExists(repository, path)
   }
@@ -22,7 +18,7 @@ export const repoPathExists = (repository: Repository, path: string): Promise<bo
 }
 
 export const repoReadFile = (repository: Repository, path: string, encoding: string = 'utf-8'): Promise<string> => {
-  if (isSSHRepo(repository)) {
+  if (repository.isSSHRepository) {
     path = sshPath(path)
     return remoteReadFile(repository, path)
   }
@@ -45,7 +41,7 @@ export async function repoReadPartialFile(
   end: number
 ): Promise<Buffer> {
   return await new Promise<Buffer>((resolve, reject) => {
-    if (isSSHRepo(repository)) {
+    if (repository.isSSHRepository) {
       path = sshPath(path)
       remoteReadPartialFile(repository, path, start, end).then(value => {
         resolve(Buffer.from(value))

--- a/app/src/lib/git/branch.ts
+++ b/app/src/lib/git/branch.ts
@@ -159,10 +159,13 @@ export async function getMergedBranches(
   branchName: string
 ): Promise<Map<string, string>> {
   const canonicalBranchRef = formatAsLocalRef(branchName)
-  const { formatArgs, parse } = createForEachRefParser({
-    sha: '%(objectname)',
-    canonicalRef: '%(refname)',
-  })
+  const { formatArgs, parse } = createForEachRefParser(
+    repository,
+    {
+      sha: '%(objectname)',
+      canonicalRef: '%(refname)',
+    }
+  )
 
   const args = ['branch', ...formatArgs, '--merged', branchName]
   const mergedBranches = new Map<string, string>()

--- a/app/src/lib/git/cherry-pick.ts
+++ b/app/src/lib/git/cherry-pick.ts
@@ -168,7 +168,10 @@ export async function cherryPick(
   const result = await git(
     [
       'cherry-pick',
-      ...commits.map(c => c.sha),
+      // HACK HACK HACK
+      // We sometimes end up with revisions with a leading "'" character, until
+      // we figure out why, let's just strip it off here.
+      ...commits.map(c => c.sha.replace(/^'/, '')),
       '--keep-redundant-commits',
       '-m 1',
     ],

--- a/app/src/lib/git/diff.ts
+++ b/app/src/lib/git/diff.ts
@@ -109,6 +109,10 @@ export async function getCommitDiff(
   commitish: string,
   hideWhitespaceInDiff: boolean = false
 ): Promise<IDiff> {
+  // HACK HACK HACK
+  // We sometimes end up with revisions with a leading "'" character, until
+  // we figure out why, let's just strip it off here.
+  commitish = commitish.replace(/^'/, '')
   const args = [
     'log',
     commitish,

--- a/app/src/lib/git/for-each-ref.ts
+++ b/app/src/lib/git/for-each-ref.ts
@@ -15,14 +15,17 @@ export async function getBranches(
   repository: Repository,
   ...prefixes: string[]
 ): Promise<ReadonlyArray<Branch>> {
-  const { formatArgs, parse } = createForEachRefParser({
-    fullName: '%(refname)',
-    shortName: '%(refname:short)',
-    upstreamShortName: '%(upstream:short)',
-    sha: '%(objectname)',
-    author: '%(author)',
-    symRef: '%(symref)',
-  })
+  const { formatArgs, parse } = createForEachRefParser(
+    repository,
+    {
+      fullName: '%(refname)',
+      shortName: '%(refname:short)',
+      upstreamShortName: '%(upstream:short)',
+      sha: '%(objectname)',
+      author: '%(author)',
+      symRef: '%(symref)',
+    }
+  )
 
   if (!prefixes || !prefixes.length) {
     prefixes = ['refs/heads', 'refs/remotes']
@@ -77,13 +80,16 @@ export async function getBranches(
 export async function getBranchesDifferingFromUpstream(
   repository: Repository
 ): Promise<ReadonlyArray<ITrackingBranch>> {
-  const { formatArgs, parse } = createForEachRefParser({
-    fullName: '%(refname)',
-    sha: '%(objectname)', // SHA
-    upstream: '%(upstream)',
-    symref: '%(symref)',
-    head: '%(HEAD)',
-  })
+  const { formatArgs, parse } = createForEachRefParser(
+    repository,
+    {
+      fullName: '%(refname)',
+      sha: '%(objectname)', // SHA
+      upstream: '%(upstream)',
+      symref: '%(symref)',
+      head: '%(HEAD)',
+    }
+  )
 
   const prefixes = ['refs/heads', 'refs/remotes']
 

--- a/app/src/lib/git/git-delimiter-parser.ts
+++ b/app/src/lib/git/git-delimiter-parser.ts
@@ -1,3 +1,5 @@
+import { Repository } from "../../models/repository"
+
 /**
  * Create a new parser suitable for parsing --format output from commands such
  * as `git log`, `git stash`, and other commands that are not derived from
@@ -52,11 +54,18 @@ export function createLogParser<T extends Record<string, string>>(fields: T) {
  *
  */
 export function createForEachRefParser<T extends Record<string, string>>(
+  repository: Repository,
   fields: T
 ) {
   const keys: Array<keyof T> = Object.keys(fields)
   const format = Object.values(fields).join('%00')
-  const formatArgs = [`--format='%00${format}%00'`]
+  let formatArgs
+  if (repository.isSSHRepository) {
+    formatArgs = [`--format='%00${format}%00'`]
+  } else {
+    formatArgs = [`--format=%00${format}%00`]
+  }
+
 
   const parse = (value: string) => {
     const records = value.split('\0')

--- a/app/src/lib/git/log.ts
+++ b/app/src/lib/git/log.ts
@@ -202,6 +202,11 @@ export async function getChangedFiles(
   repository: Repository,
   sha: string
 ): Promise<IChangesetData> {
+  // HACK HACK HACK
+  // We sometimes end up with revisions with a leading "'" character, until
+  // we figure out why, let's just strip it off here.
+  sha = sha.replace(/^'/, '')
+
   // opt-in for rename detection (-M) and copies detection (-C)
   // this is equivalent to the user configuring 'diff.renames' to 'copies'
   // NOTE: order here matters - doing -M before -C means copies aren't detected

--- a/app/src/lib/git/stash.ts
+++ b/app/src/lib/git/stash.ts
@@ -108,8 +108,12 @@ export async function getLastDesktopStashEntryForBranch(
 }
 
 /** Creates a stash entry message that indicates the entry was created by Desktop */
-export function createDesktopStashMessage(branchName: string) {
-  return `${DesktopStashEntryMarker}<${branchName}>`
+export function createDesktopStashMessage(repository: Repository, branchName: string) {
+  if (repository.isSSHRepository) {
+    return `'${DesktopStashEntryMarker}<${branchName}>'`
+  } else {
+    return `${DesktopStashEntryMarker}<${branchName}>`
+  }
 }
 
 /**
@@ -130,7 +134,7 @@ export async function createDesktopStashEntry(
   await stageFiles(repository, fullySelectedUntrackedFiles)
 
   const branchName = typeof branch === 'string' ? branch : branch.name
-  const message = createDesktopStashMessage(branchName)
+  const message = createDesktopStashMessage(repository, branchName)
   const args = ['stash', 'push', '-m', message]
 
   const result = await git(args, repository.path, 'createStashEntry', {

--- a/app/src/lib/stores/app-store.ts
+++ b/app/src/lib/stores/app-store.ts
@@ -304,6 +304,7 @@ import { offsetFromNow } from '../offset-from'
 import { findContributionTargetDefaultBranch } from '../branch'
 import { ValidNotificationPullRequestReview } from '../valid-notification-pull-request-review'
 import { determineMergeability } from '../git/merge-tree'
+import { setCodespacesGitConfig } from '../virtual/git/codespaces-config'
 
 const LastSelectedRepositoryIDKey = 'last-selected-repository-id'
 
@@ -3230,6 +3231,7 @@ export class AppStore extends TypedBaseStore<IAppState> {
       gitStore.loadStashEntries(),
       this._refreshAuthor(repository),
       refreshSectionPromise,
+      setCodespacesGitConfig(repository),
     ])
 
     await gitStore.refreshTags()

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -28,7 +28,6 @@ import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { clearTagsToPush } from './helpers/tags-to-push-storage'
 import { IMatchedGitHubRepository } from '../repository-matching'
 import { shallowEquals } from '../equality'
-import { setCodespacesGitConfig } from '../virtual/git/codespaces-config'
 
 type AddRepositoryOptions = {
   missing?: boolean
@@ -154,7 +153,6 @@ export class RepositoriesStore extends TypedBaseStore<
       repo.alias,
       repo.workflowPreferences,
       repo.isTutorialRepository,
-      repo.isSSHRepository
     )
   }
 
@@ -254,20 +252,11 @@ export class RepositoriesStore extends TypedBaseStore<
           missing: opts?.missing ?? false,
           lastStashCheckDate: null,
           alias: null,
-          isSSHRepository: path.startsWith('ssh::'),
         }
         const id = await this.db.repositories.add(dbRepo)
         return this.toRepository({ id, ...dbRepo })
       }
     )
-    // HACk HACK HACK
-    // TODO: find a better place for first-time setup of Codespaces git credentials
-    if (repository.isSSHRepository) {
-      const result = await setCodespacesGitConfig(repository.path)
-      if (result) {
-        log.info(`[Codespaces] set git config for ${repository.path}`)
-      }
-    }
 
     this.emitUpdatedRepositories()
 

--- a/app/src/lib/stores/repositories-store.ts
+++ b/app/src/lib/stores/repositories-store.ts
@@ -28,6 +28,7 @@ import { WorkflowPreferences } from '../../models/workflow-preferences'
 import { clearTagsToPush } from './helpers/tags-to-push-storage'
 import { IMatchedGitHubRepository } from '../repository-matching'
 import { shallowEquals } from '../equality'
+import { setCodespacesGitConfig } from '../virtual/git/codespaces-config'
 
 type AddRepositoryOptions = {
   missing?: boolean
@@ -259,6 +260,14 @@ export class RepositoriesStore extends TypedBaseStore<
         return this.toRepository({ id, ...dbRepo })
       }
     )
+    // HACk HACK HACK
+    // TODO: find a better place for first-time setup of Codespaces git credentials
+    if (repository.isSSHRepository) {
+      const result = await setCodespacesGitConfig(repository.path)
+      if (result) {
+        log.info(`[Codespaces] set git config for ${repository.path}`)
+      }
+    }
 
     this.emitUpdatedRepositories()
 

--- a/app/src/lib/virtual/git/codespaces-config.ts
+++ b/app/src/lib/virtual/git/codespaces-config.ts
@@ -1,15 +1,20 @@
+import { Repository } from '../../../models/repository'
 import * as cp from 'child_process'
 
-export const setCodespacesGitConfig = (path: string): Promise<boolean> => {
-  const host = path.split('::')[1]
+export const setCodespacesGitConfig = (repository: Repository): Promise<boolean> => {
+  const host = repository.path.split('::')[1]
   const args = [
     host,
-    `grep -q restore-secrets /.codespaces/bin/gitcredential_github.sh || sudo sed -i '/^echo protocol/i . /etc/profile.d/00-restore-secrets.sh' /.codespaces/bin/gitcredential_github.sh`,
+    `grep -q codespaces /.codespaces/bin/gitcredential_github.sh || sudo sed -i '/^echo protocol/i . /etc/profile.d/codespaces.sh' /.codespaces/bin/gitcredential_github.sh`,
   ]
-  log.info(`Executing setCodespacesGitConfig: ssh '${args.join(' ')}'`)
   return new Promise((resolve) => {
-    cp.execFile('ssh', args, (error) => {
-      resolve(!error)
-    })
+    if (repository.isSSHRepository) {
+      log.info(`Executing setCodespacesGitConfig: ssh '${args.join(' ')}'`)
+      cp.execFile('ssh', args, (error) => {
+        resolve(!error)
+      })
+    } else {
+      resolve(false)
+    }
   })
 }

--- a/app/src/lib/virtual/git/codespaces-config.ts
+++ b/app/src/lib/virtual/git/codespaces-config.ts
@@ -1,0 +1,15 @@
+import * as cp from 'child_process'
+
+export const setCodespacesGitConfig = (path: string): Promise<boolean> => {
+  const host = path.split('::')[1]
+  const args = [
+    host,
+    `grep -q restore-secrets /.codespaces/bin/gitcredential_github.sh || sudo sed -i '/^echo protocol/i . /etc/profile.d/00-restore-secrets.sh' /.codespaces/bin/gitcredential_github.sh`,
+  ]
+  log.info(`Executing setCodespacesGitConfig: ssh '${args.join(' ')}'`)
+  return new Promise((resolve) => {
+    cp.execFile('ssh', args, (error) => {
+      resolve(!error)
+    })
+  })
+}

--- a/app/src/models/repository.ts
+++ b/app/src/models/repository.ts
@@ -59,7 +59,6 @@ export class Repository {
      * which introduces new users to some core concepts of Git and GitHub.
      */
     public readonly isTutorialRepository: boolean = false,
-    public readonly isSSHRepository: boolean = false
   ) {
     this.mainWorkTree = { path }
     this.name = (gitHubRepository && gitHubRepository.name) || getBaseName(path)
@@ -78,6 +77,10 @@ export class Repository {
 
   public get path(): string {
     return this.mainWorkTree.path
+  }
+
+  public get isSSHRepository(): boolean {
+    return this.path.startsWith('ssh::')
   }
 }
 

--- a/changelog.json
+++ b/changelog.json
@@ -1,5 +1,11 @@
 {
   "releases": {
+    "3.1.2-beta2-virtual": [
+      "[Fixed] Git credentials will now be configured on Codespaces",
+      "[Fixed] Cherry picking to new branches now _should_ work over SSH",
+      "[Fixed] Ref parsing _should_ work a little better...but it's hacky",
+      "[Fixed] Stash can now be pushed and popped over SSH"
+    ],
     "3.1.2-beta1-virtual": [
       "[Improved] Virtual repos now use an SSH transport removing the need to run an HTTP server on the remote host - #7",
       "[Fixed] Support discarding new file for virtual repos - #8",


### PR DESCRIPTION
1. I didn't notice that git auth was borked.

The problem is that the credential helper used to ensure git stuff is authed relies on a login shell implicitly by the nature of it inspecting the `GITHUB_TOKEN` env var. Since we're running ssh commands to do stuff that environment variable isn't set. Instead of dealing with trying to spawn a logic shell, we patch the credential helper to set those env vars itself instead of making someone else do its work 😄. It'll slow down any authed git stuff a bit, but that should be the minority of operations.

2. I also broke local repos

Turns out that what I _thought_ was some super helpful shell escaping actually caused issues that I don't understand when not run over ssh (via like the specific Node calls at least). Instead of digging into it, for now I'm happy to set the formatting based on the environment we're operating in.